### PR TITLE
Relaxed Cross-Origin Permissions For Draw Tool

### DIFF
--- a/examples/main.jsx
+++ b/examples/main.jsx
@@ -630,7 +630,8 @@ class SketchFieldDemo extends React.Component {
                     <Button
                       variant="outlined"
                       onClick={(e) => {
-                        this._sketch.addImg(this.state.imageUrl)
+                        //Setting options to relax crossOrigin requirements for student preview of s3 resources
+                        this._sketch.addImg(this.state.imageUrl, { crossOrigin: '*' })
                       }}>
                       Load Image from URL
                     </Button>
@@ -638,7 +639,8 @@ class SketchFieldDemo extends React.Component {
                   <br/>
                   <Button
                     variant="outlined"
-                    onClick={(e) => this._sketch.addImg(dataUrl)}>
+                    //Setting options to relax crossOrigin requirements for student preview of s3 resources
+                    onClick={(e) => this._sketch.addImg(dataUrl, { crossOrigin: '*' })}>
                     Load Image from Data URL
                   </Button>
                 </CardContent>

--- a/examples/main.jsx
+++ b/examples/main.jsx
@@ -630,7 +630,6 @@ class SketchFieldDemo extends React.Component {
                     <Button
                       variant="outlined"
                       onClick={(e) => {
-                        //Setting options to relax crossOrigin requirements for student preview of s3 resources
                         this._sketch.addImg(this.state.imageUrl, { crossOrigin: '*' })
                       }}>
                       Load Image from URL
@@ -639,7 +638,6 @@ class SketchFieldDemo extends React.Component {
                   <br/>
                   <Button
                     variant="outlined"
-                    //Setting options to relax crossOrigin requirements for student preview of s3 resources
                     onClick={(e) => this._sketch.addImg(dataUrl, { crossOrigin: '*' })}>
                     Load Image from Data URL
                   </Button>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,7 +88,7 @@ declare module '@kiddom/react-sketch' {
 		 *   scale: <Number: initial scale of image>
 		 * }
 		 */
-		addImg(dataUrl: string, options?: { left?: number, top?: number, scale?: number }): void
+		addImg(dataUrl: string, options?: { left?: number, top?: number, scale?: number, options?: object }): void
 
 		/**
 		 * Zoom the drawing by the factor specified

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,7 +88,7 @@ declare module '@kiddom/react-sketch' {
 		 *   scale: <Number: initial scale of image>
 		 * }
 		 */
-		addImg(dataUrl: string, options?: { left?: number, top?: number, scale?: number, options?: object }): void
+		addImg(dataUrl: string, options?: { left?: number, top?: number, scale?: number, crossOrigin?: string }): void
 
 		/**
 		 * Zoom the drawing by the factor specified


### PR DESCRIPTION
Ingested drawing questions with background image are not properly loading background images in student preview due to a CORS issue. Currently this issue is only seen in Google Chrome.

Jira Ticket:
https://kiddom.atlassian.net/secure/RapidBoard.jspa?rapidView=1&modal=detail&selectedIssue=CC-437

