### PR TITLE
change the default cursor to be crosshair for line

### DIFF
--- a/src/line.js
+++ b/src/line.js
@@ -12,6 +12,7 @@ class Line extends FabricCanvasTool {
     canvas.forEachObject((o) => o.selectable = o.evented = false);
     this._width = props.lineWidth;
     this._color = props.lineColor;
+    canvas.defaultCursor = 'crosshair';
   }
 
   doMouseDown(o) {


### PR DESCRIPTION
Based on QA and design feedback, change the default curser of Line tool to be `crosshair`

https://share.getcloudapp.com/DOu42mz7

Ticket: https://kiddom.atlassian.net/browse/CE-193?atlOrigin=eyJpIjoiNzdjMzMyNjgyMWIyNGFiZWFkMzVmMDExMmRmZjNjNzEiLCJwIjoiaiJ9