### PR TITLE
add highlighter color and width

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ class SketchFieldDemo extends React.Component {
                          height='768px' 
                          tool={Tools.Pencil} 
                          lineColor='black'
-                         lineWidth={3}/>
+                         lineWidth={3}
+                         highlightColor = 'yellow'
+                         highlightWidth = {3}
+                         />
         )
      }
 }
@@ -54,7 +57,9 @@ Configuration Options
 |---                |---    	            |---	        |---                                                                |
 | tool              | Enumeration (string)  | pencil        | The tool to use, can be select, pencil, circle, rectangle, pan    |
 | lineColor         | String                | black         | The color of the line   	                                        |
-| lineWidth         | Number                | 1             | The width of the line                                             | 
+| lineWidth         | Number                | 1             | The width of the line 
+| highlightColor         | String                | yellow         | The color of the line   	                                        |
+| highlightWidth         | Number                | 1             | The width of the line                                            | 
 | fillColor         | String                | transparent   | The fill color (hex format) of the shape when applicable (e.g. circle) |
 | backgroundColor   | String                | transparent   | The the background color of the sketch in hex or rgba             |
 | undoSteps         | Number                | 15            | number of undo/redo steps to maintain                             |
@@ -76,7 +81,8 @@ Available tools
 | Rectangle         | Create rectangles |
 | Circle            | Create circles |
 | Rectangle         | Create Rectangles |
-| Select            | Disables drawing and gives you the ability to modify existing elements in the canvas |
+| Select            | Disables drawing and gives you the ability to modify existing elements in the canvas
+| Highlighter       | Highlight drawing  |
 | Pan               | Disables drawing and gives you the ability to move the complete canvas at will, useful to adjust the canvas when zooming in or out (thank you [wmaillard](https://github.com/wmaillard)) |
 
 

--- a/examples/main.jsx
+++ b/examples/main.jsx
@@ -531,7 +531,7 @@ class SketchFieldDemo extends React.Component {
                   <br/>
                   <CompactPicker
                     id='lineColor' color={this.state.lineColor}
-                    onChange={(color) => this.setState({ lineColor: color.hex, highlighterColor: color.hex })}/>
+                    onChange={(color) => this.setState({ lineColor: color.hex })}/>
                   <br/>
                   <br/>
                   <FormControlLabel

--- a/examples/main.jsx
+++ b/examples/main.jsx
@@ -117,6 +117,8 @@ class SketchFieldDemo extends React.Component {
     this.state = {
       lineWidth: 10,
       lineColor: 'black',
+      highlighterColor: 'yellow',
+      highlighterWidth: 10,
       fillColor: '#68CCCA',
       backgroundColor: 'transparent',
       shadowWidth: 0,
@@ -346,6 +348,8 @@ class SketchFieldDemo extends React.Component {
               ref={c => (this._sketch = c)}
               lineColor={this.state.lineColor}
               lineWidth={this.state.lineWidth}
+              highlighterColor={this.state.highlighterColor}
+              highlighterWidth={this.state.highlighterWidth}
               fillColor={
                 this.state.fillWithColor
                   ? this.state.fillColor
@@ -527,7 +531,7 @@ class SketchFieldDemo extends React.Component {
                   <br/>
                   <CompactPicker
                     id='lineColor' color={this.state.lineColor}
-                    onChange={(color) => this.setState({ lineColor: color.hex })}/>
+                    onChange={(color) => this.setState({ lineColor: color.hex, highlighterColor: color.hex })}/>
                   <br/>
                   <br/>
                   <FormControlLabel
@@ -541,6 +545,14 @@ class SketchFieldDemo extends React.Component {
                   <CompactPicker
                     color={this.state.fillColor}
                     onChange={(color) => this.setState({ fillColor: color.hex })}/>
+                  <br />
+                  <br />
+                  <label htmlFor='highlightColor'>Highlighter</label>
+                  <br />
+                  <CompactPicker
+                    id='lineColor' color={this.state.highlighterColor}
+                    onChange={(color) => this.setState({ highlighterColor: color.hex })} />
+                  <br />
                 </CardContent>
               </Collapse>
             </Card>

--- a/src/SketchField.jsx
+++ b/src/SketchField.jsx
@@ -95,7 +95,7 @@ class SketchField extends PureComponent {
   static defaultProps = {
     lineColor: 'black',
     lineWidth: 10,
-    highligherColor: 'pink',
+    highligherColor: 'yellow',
     highligherWidth: 10,
     textColor: 'black',
     textSize: 16,

--- a/src/SketchField.jsx
+++ b/src/SketchField.jsx
@@ -29,6 +29,10 @@ class SketchField extends PureComponent {
     lineColor: PropTypes.string,
     // The width of the line
     lineWidth: PropTypes.number,
+    // the color of the highlighter line
+    highligherColor: PropTypes.string,
+		//the width of the highlighter line
+    highlighterWidth: PropTypes.number,
     // the color of the text
     textColor: PropTypes.string,
     // the size of the text
@@ -91,6 +95,8 @@ class SketchField extends PureComponent {
   static defaultProps = {
     lineColor: 'black',
     lineWidth: 10,
+    highligherColor: 'pink',
+    highligherWidth: 10,
     textColor: 'black',
     textSize: 16,
     fillColor: 'transparent',

--- a/src/highlighter.js
+++ b/src/highlighter.js
@@ -6,8 +6,8 @@ class Highlighter extends FabricCanvasTool {
 
   configureCanvas(props) {
     this._canvas.isDrawingMode = true;
-    this._canvas.freeDrawingBrush.width = props.lineWidth;
-    this._canvas.freeDrawingBrush.color = props.lineColor.indexOf('#') > -1 ? hexToRgbA(props.lineColor) : hexToRgbA(colorNameToHex(props.lineColor));
+    this._canvas.freeDrawingBrush.width = props.highlighterWidth;
+    this._canvas.freeDrawingBrush.color = props.highlighterColor.indexOf('#') > -1 ? hexToRgbA(props.highlighterColor) : hexToRgbA(colorNameToHex(props.highlighterColor));
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ declare module '@kiddom/react-sketch' {
 	    RectangleLabel: string;
 	    Select: string;
 	    Pan: string;
+		Highlighter: string;
 	    DefaultTool: string;
 	} = {
 	    Circle: 'circle',
@@ -20,6 +21,7 @@ declare module '@kiddom/react-sketch' {
 	    RectangleLabel: 'rectangle-label',
 	    Select: 'select',
 	    Pan: 'pan',
+		Highlighter: 'highlighter',
 	    DefaultTool: 'default-tool',
 	}
 	export class SketchField extends React.PureComponent<{
@@ -27,10 +29,14 @@ declare module '@kiddom/react-sketch' {
 		lineColor?: string
 		// The width of the line
 		lineWidth?: number
+		// the color of the highlighter line
+		highligherColor?: string
+		//the width of the highlighter line
+		highlighterWidth?:number
 		// the color of the text
-		textColor: PropTypes.string,
+		textColor?: PropTypes.string
 		// the size of the text
-		textSize: PropTypes.number,
+		textSize?: PropTypes.number
 		// the fill color of the shape when applicable
 		fillColor?: string
 		// the background color of the sketch

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,12 +31,12 @@ declare module '@kiddom/react-sketch' {
 		lineWidth?: number
 		// the color of the highlighter line
 		highligherColor?: string
-		//the width of the highlighter line
+		// the width of the highlighter line
 		highlighterWidth?:number
 		// the color of the text
-		textColor?: PropTypes.string
+		textColor: PropTypes.string,
 		// the size of the text
-		textSize?: PropTypes.number
+		textSize: PropTypes.number,
 		// the fill color of the shape when applicable
 		fillColor?: string
 		// the background color of the sketch


### PR DESCRIPTION
This PR is adding highlighter color and width as an independent state. Otherwise it will share the same state with pencil tool..Also change the adding this feature in demo and adding the explanation in readme file

Ticket:
https://kiddom.atlassian.net/browse/CE-18?atlOrigin=eyJpIjoiYjBlODJhMmRlOGRiNDU4MDkzMjUxZmFlZWNkNDdiNTgiLCJwIjoiaiJ9